### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/clean-deployment.yml
+++ b/.github/workflows/clean-deployment.yml
@@ -22,6 +22,9 @@ jobs:
 
   delete_runs:
     runs-on: ubuntu-latest
+    permissions:
+      actions: write
+      contents: read
     
     steps:
       - name: Delete workflow runs


### PR DESCRIPTION
Potential fix for [https://github.com/ManuRS/manurs.github.io/security/code-scanning/1](https://github.com/ManuRS/manurs.github.io/security/code-scanning/1)

In general, this issue is fixed by explicitly adding a `permissions` block to the workflow (at the root or per job) that grants only the scopes required by that workflow/job. This prevents the `GITHUB_TOKEN` from implicitly inheriting broader repository or organization defaults (potentially read‑write on many scopes).

For this specific workflow, the `cleanup` job already has `permissions: write-all`, which is broad but explicit. The `delete_runs` job has no `permissions`, so we should add a job-level permissions block. The `dmvict/clean-workflow-runs` action deletes workflow runs via the Actions API, which requires `actions: write`, but does not require general repo content write access. A reasonable least‑privilege configuration for this job is:

```yaml
permissions:
  actions: write
  contents: read
```

`actions: write` allows managing workflow runs; `contents: read` covers basic repository read operations that GitHub or the action might implicitly need. We add this block directly under `runs-on: ubuntu-latest` in the `delete_runs` job, keeping all existing functionality intact while satisfying CodeQL and improving security.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
